### PR TITLE
Fix: navigateToResultPage navigate 방식 수정

### DIFF
--- a/src/hooks/useNavigateToResultPage.ts
+++ b/src/hooks/useNavigateToResultPage.ts
@@ -4,11 +4,7 @@ export const useNavigateToResultPage = () => {
   const navigate = useNavigate();
 
   const navigateToResultPage = (category: string) => {
-    navigate('/searchResult', {
-      state: {
-        category: category
-      }
-    });
+    navigate(`/searchResult?category=${category}`);
   };
 
   return {


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #37 

## 작업 내용 (변경 사항)
- 기존 navigate 시 state 전달하는 방법에서 **쿼리 스트링** 방법으로 수정했습니다.
  - `useSearchParams` 사용해서 카테고리 정보 가져오시면 됩니다. @seungsimdang 
  ```
  const [searchParams, ] = useSearchParams();
  const category = searchParams.get('category');
  console.log(category); // hotel, motel, pension, all
  ```

## 스크린샷
<img width="385" alt="image" src="https://github.com/YBEMiniProjectTeam/MINI-Front/assets/63582234/9fd704e7-2c79-4e7d-86eb-f6f234cfc72b">


