### PR TITLE
Feat: 숙소 싱글 뷰 캐러셀 기능 구현 및 디자인 수정

### DIFF
--- a/src/components/Main/AccommodationSingleView/AccommodationSingleView.styles.ts
+++ b/src/components/Main/AccommodationSingleView/AccommodationSingleView.styles.ts
@@ -69,21 +69,21 @@ const ArrowButtonWrapper = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 2.2rem;
+  height: 2.2rem;
 
   &:hover {
     cursor: pointer;
-    background: rgba(0, 0, 0, 0.07);
+    background: rgba(0, 0, 0, 0.05);
   }
 `;
 
 export const LeftArrowButtonWrapper = styled(ArrowButtonWrapper)`
   left: 12px;
-  transform: translate(-50%, -50%);
 `;
 
 export const RightArrowButtonWrapper = styled(ArrowButtonWrapper)`
   right: 12px;
-  transform: translate(50%, -50%);
 `;
 
 export const StyledSlider = styled(Slider)`
@@ -97,6 +97,8 @@ export const StyledSlider = styled(Slider)`
 `;
 
 export const SwiperItem = styled.div`
+  outline: none;
+  
   &:hover {
     cursor: pointer;
   }
@@ -105,7 +107,6 @@ export const SwiperItem = styled.div`
     width: 696px;
     height: 480px;
     object-fit: cover;
-    outline: none;
   }
 `;
 
@@ -157,5 +158,5 @@ export const InformationPriceTxt = styled.span`
   line-height: 16px;
   font-weight: 500;
   color: #4D4D4D;
+  font-size: 0.8rem;
 `;
-

--- a/src/components/Main/AccommodationSingleView/AccommodationSingleView.styles.ts
+++ b/src/components/Main/AccommodationSingleView/AccommodationSingleView.styles.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import Slider from "react-slick";
 
 export const SingleViewWrapper = styled.div`
   padding: 16px 0px 0px;
@@ -62,11 +63,12 @@ export const SwiperWrapper = styled.div`
 
 const ArrowButtonWrapper = styled.button`
   border-radius: 50%;
-  padding: 0.25rem;
-  display: flex;
   position: absolute;
   top: 50%;
   z-index: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   &:hover {
     cursor: pointer;
@@ -84,10 +86,27 @@ export const RightArrowButtonWrapper = styled(ArrowButtonWrapper)`
   transform: translate(50%, -50%);
 `;
 
+export const StyledSlider = styled(Slider)`
+  max-width: 768px; 
+
+  .slick-prev::before,
+  .slick-next::before {
+    opacity: 0;
+    display: none;
+  }
+`;
+
 export const SwiperItem = styled.div`
-  flex: 0 0 calc(684px + 10px); 
-  margin: 0 12px;
-  position: relative;
+  &:hover {
+    cursor: pointer;
+  }
+
+  img {
+    width: 696px;
+    height: 480px;
+    object-fit: cover;
+    outline: none;
+  }
 `;
 
 export const InformationWrapper = styled.div`

--- a/src/components/Main/AccommodationSingleView/AccommodationSingleView.tsx
+++ b/src/components/Main/AccommodationSingleView/AccommodationSingleView.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import * as styled from './AccommodationSingleView.styles';
 import { ArrowForwardIcon } from '@chakra-ui/icons';
 import { IoIosArrowForward, IoIosArrowBack } from "react-icons/io";
 
-// 임시 데이터
+//
 const AccommodationData = [
   {
     imageUrl: "https://yaimg.yanolja.com/v5/2022/10/17/15/634d7563600ed4.17945107.jpg",
@@ -47,17 +47,17 @@ export const AccommodationSingleView = () => {
     speed: 500,
     slidesToShow: 1,
     centerMode: true,
-    centerPadding: "30px",
+    centerPadding: "28px",
     slidesToScroll: 1,
     beforeChange: (current: number, next: number) => setCurrentSlide(next),
     nextArrow: (
       <styled.RightArrowButtonWrapper>
-        <IoIosArrowForward color="black" size="2rem"/>
+        <IoIosArrowForward color="#4D4D4D" size="2rem"/>
       </styled.RightArrowButtonWrapper>
     ),
     prevArrow: (
       <styled.LeftArrowButtonWrapper>
-        <IoIosArrowBack color="black" size="2rem"/>
+        <IoIosArrowBack color="#4D4D4D" size="2rem"/>
       </styled.LeftArrowButtonWrapper>
     ),
   };

--- a/src/components/Main/AccommodationSingleView/AccommodationSingleView.tsx
+++ b/src/components/Main/AccommodationSingleView/AccommodationSingleView.tsx
@@ -1,9 +1,67 @@
-import React from "react";
+import React, { useState } from "react";
 import * as styled from './AccommodationSingleView.styles';
 import { ArrowForwardIcon } from '@chakra-ui/icons';
 import { IoIosArrowForward, IoIosArrowBack } from "react-icons/io";
 
+// 임시 데이터
+const AccommodationData = [
+  {
+    imageUrl: "https://yaimg.yanolja.com/v5/2022/10/17/15/634d7563600ed4.17945107.jpg",
+    region: "강원",
+    name: "강릉 세인트존스 호텔",
+    price: "89,000",
+  },
+  {
+    imageUrl: "https://yaimg.yanolja.com/v5/2022/09/02/16/63122c1e9ce9e4.94265324.jpg",
+    region: "서울",
+    name: "노보텔 스위트 앰배서더 서울 용산",
+    price: "242,550",
+  },
+  {
+    imageUrl: "https://yaimg.yanolja.com/v5/2022/09/27/20/633356449b6ed6.90935628.jpg",
+    region: "제주",
+    name: "해비치 호텔&리조트",
+    price: "245,840",
+  },
+  {
+    imageUrl: "https://yaimg.yanolja.com/v5/2022/10/27/17/635abceb287712.74610369.jpg",
+    region: "경기",
+    name: "라마다 앙코르 바이 윈덤 김포 한강 호텔",
+    price: "115,000",
+  },
+  {
+    imageUrl: "https://yaimg.yanolja.com/v5/2022/07/20/19/62d8568eb73523.97030183.jpg",
+    region: "경기",
+    name: "롤링힐스 호텔",
+    price: "189,000",
+  },
+];
+
 export const AccommodationSingleView = () => {
+  const [currentSlide, setCurrentSlide] = useState<number>(0);
+
+  const settings = {
+    dots: false,
+    infinite: false,
+    arrows: true,
+    speed: 500,
+    slidesToShow: 1,
+    centerMode: true,
+    centerPadding: "30px",
+    slidesToScroll: 1,
+    beforeChange: (current: number, next: number) => setCurrentSlide(next),
+    nextArrow: (
+      <styled.RightArrowButtonWrapper>
+        <IoIosArrowForward color="black" size="2rem"/>
+      </styled.RightArrowButtonWrapper>
+    ),
+    prevArrow: (
+      <styled.LeftArrowButtonWrapper>
+        <IoIosArrowBack color="black" size="2rem"/>
+      </styled.LeftArrowButtonWrapper>
+    ),
+  };
+
   return (
     <styled.SingleViewWrapper>
       <styled.MainViewTitleWrapper>
@@ -19,36 +77,26 @@ export const AccommodationSingleView = () => {
         </styled.MoreButtonWrapper>
       </styled.MainViewTitleWrapper>
       <styled.SwiperContainer>
-        <styled.LeftArrowButtonWrapper>
-          <IoIosArrowBack size="1.2rem"/>
-        </styled.LeftArrowButtonWrapper>
-        <styled.SwiperWrapper>
-          <styled.SwiperItem>
-            <a href="/products/:productDetail">
-              <img src="https://yaimg.yanolja.com/v5/2022/10/17/15/634d7563600ed4.17945107.jpg"></img>
-            </a>
-          </styled.SwiperItem>
-          <styled.SwiperItem>
-            <a href="/products/:productDetail">
-              <img src="https://yaimg.yanolja.com/v5/2022/10/17/15/634d7563600ed4.17945107.jpg"></img>
-            </a>
-          </styled.SwiperItem>
-          <styled.SwiperItem>
-            <a href="/products/:productDetail">
-              <img src="https://yaimg.yanolja.com/v5/2022/10/17/15/634d7563600ed4.17945107.jpg"></img>
-            </a>
-          </styled.SwiperItem>
-        </styled.SwiperWrapper>
-        <styled.RightArrowButtonWrapper>
-          <IoIosArrowForward size="1.2rem"/>
-        </styled.RightArrowButtonWrapper>
+        <styled.StyledSlider {...settings}>
+          {AccommodationData.map((item, index) => (
+            <styled.SwiperItem key={index}>
+              <img src={item.imageUrl} alt={`Slide ${index + 1}`} />
+            </styled.SwiperItem>
+          ))}
+        </styled.StyledSlider>
       </styled.SwiperContainer>
       <styled.InformationWrapper>
         <styled.InformationInner>
-          <styled.InformationRegion>강원</styled.InformationRegion>
-          <styled.InformationName>강릉 세인트존스 호텔</styled.InformationName>
+          <styled.InformationRegion>
+            {AccommodationData[currentSlide].region}
+          </styled.InformationRegion>
+          <styled.InformationName>
+            {AccommodationData[currentSlide].name}
+          </styled.InformationName>
           <div>
-            <styled.InformationPrice>89,000</styled.InformationPrice>
+            <styled.InformationPrice>
+              {AccommodationData[currentSlide].price}
+            </styled.InformationPrice>
             <styled.InformationPriceTxt>원부터</styled.InformationPriceTxt>
           </div>
         </styled.InformationInner>


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #34 

## 작업 내용 (변경 사항)
- 숙소 싱글 뷰 이미지 캐러셀 기능 구현 (center mode)
  - 숙소 이미지에 맞춰 정보도 같이 업데이트
- 캐러셀 상세 디자인 수정
  - 버튼 크기, 위치, 색 수정 (드래그 형태의 캐러셀은 UX면에서 좋지 않다고 하여 버튼을 추가했습니다)
  - 이전 이미지, 다음 이미지 일부 보이도록 

## 스크린샷
<img width="788" alt="image" src="https://github.com/YBEMiniProjectTeam/MINI-Front/assets/63582234/d0ad3376-c451-42de-8f96-4af6bbca69a4">

## 리뷰 요청 사항
