### PR TITLE
Fix: 카테고리 메뉴 바 수정

### DIFF
--- a/src/components/Main/MainCategoryMenu/MainCategoryMenu.styles.ts
+++ b/src/components/Main/MainCategoryMenu/MainCategoryMenu.styles.ts
@@ -32,6 +32,9 @@ export const CategoryMenuItem = styled.div`
 export const MenuIcon = styled.div`
   width: 40px;
   height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 export const MenuTitle = styled.div`

--- a/src/components/Main/MainCategoryMenu/MainCategoryMenu.tsx
+++ b/src/components/Main/MainCategoryMenu/MainCategoryMenu.tsx
@@ -1,6 +1,7 @@
 import * as styled from "./MainCategoryMenu.styles";
 import { MdHotel as AllIcon } from "react-icons/md";
 import { FaHotel as HotelIcon } from "react-icons/fa6";
+import { FaBuildingColumns as ResortIcon } from "react-icons/fa6";
 import { RiHotelFill as MotelIcon } from "react-icons/ri";
 import { FaHouse as PensionIcon } from "react-icons/fa6";
 import { MainCategoryMenuItem } from "./MainCategoryMenuItem";
@@ -12,14 +13,20 @@ export const MainCategoryMenu = () => {
         <MainCategoryMenuItem 
           icon={<AllIcon />} 
           size="2.3rem" 
-          title="국내 모든 숙소" 
+          title="모든 숙소" 
           category="all"
         />
         <MainCategoryMenuItem 
           icon={<HotelIcon />} 
           size="1.9rem" 
-          title="호텔/리조트"
+          title="호텔"
           category="hotel"
+        />
+        <MainCategoryMenuItem 
+          icon={<ResortIcon />} 
+          size="1.9rem" 
+          title="리조트"
+          category="resort"
         />
         <MainCategoryMenuItem 
           icon={<MotelIcon />} 
@@ -30,7 +37,7 @@ export const MainCategoryMenu = () => {
         <MainCategoryMenuItem 
           icon={<PensionIcon />} 
           size="2.2rem" 
-          title="풀빌라/펜션" 
+          title="펜션" 
           category="pension"
         />
       </styled.CategoryMenuWrapper>

--- a/src/components/Main/MainCategoryMenu/MainCategoryMenuItem.tsx
+++ b/src/components/Main/MainCategoryMenu/MainCategoryMenuItem.tsx
@@ -13,8 +13,12 @@ export const MainCategoryMenuItem: React.FC<MainCategoryMenuItemProps> = ({
   const { navigateToResultPage } = useNavigateToResultPage();
 
   return (
-    <styled.CategoryMenuItem onClick={() => navigateToResultPage(category)}>
-      {React.cloneElement(icon, { size, color: iconColor })}
+    <styled.CategoryMenuItem
+      onClick={() => navigateToResultPage(category)}
+    >
+      <styled.MenuIcon>
+        {React.cloneElement(icon, { size, color: iconColor })}
+      </styled.MenuIcon>
       <styled.MenuTitle>{title}</styled.MenuTitle>
     </styled.CategoryMenuItem>
   );


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #39 

## 작업 내용 (변경 사항)
- 데이터 분류에 맞게 카테고리 메뉴 수정
  - 풀빌라/펜션 -> 펜션
  - 호텔/리조트 -> 호텔, 리조트
 
기존 방식대로 `useSearchParams` 사용하시면 되고, all, hotel, resort, motel, pension 중 하나로 넘어갑니다! @seungsimdang 
```
const [searchParams] = useSearchParams();
const category = searchParams.get("category");
console.log(category); // all, hotel, resort, motel, pension 중 하나
```


## 스크린샷
<img width="734" alt="image" src="https://github.com/YBEMiniProjectTeam/MINI-Front/assets/63582234/0da06313-e433-48e1-a992-7d9d54100273">
