### PR TITLE
Feat: 메인 페이지 navigate 추가

### DIFF
--- a/src/components/Main/AccommodationGridView/AccommodationGridItem.tsx
+++ b/src/components/Main/AccommodationGridView/AccommodationGridItem.tsx
@@ -1,14 +1,18 @@
+import { useNavigateToDetailPage } from "@/hooks/useNavigateToDetailPage";
 import * as styled from "./AccommodationGridView.styles";
 import type { GridItemProps } from "./AccommodationGridView.types";
 
 export const AccommodationGridItem: React.FC<GridItemProps> = ({
+  id,
   imageUrl,
   summary,
   name,
   price
-}) => (
-  <a href="products/:productDetail">
-    <styled.GridItem>
+}) => {
+  const { navigateToDetailPage } = useNavigateToDetailPage();
+
+  return (
+    <styled.GridItem onClick={() => navigateToDetailPage(id)}>
       <styled.GridItemImageWrapper>
         <styled.GridItemImage src={imageUrl} />
       </styled.GridItemImageWrapper>
@@ -19,5 +23,5 @@ export const AccommodationGridItem: React.FC<GridItemProps> = ({
         <styled.InformationPriceTxt>원부터</styled.InformationPriceTxt>
       </styled.InformationWrapper>
     </styled.GridItem>
-  </a>
-);
+  );
+}

--- a/src/components/Main/AccommodationGridView/AccommodationGridView.styles.ts
+++ b/src/components/Main/AccommodationGridView/AccommodationGridView.styles.ts
@@ -89,6 +89,10 @@ export const GridItem = styled.div`
   &:nth-child(2n) {
     margin-left: 1%;
   }
+
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 export const GridItemImageWrapper = styled.div`

--- a/src/components/Main/AccommodationGridView/AccommodationGridView.tsx
+++ b/src/components/Main/AccommodationGridView/AccommodationGridView.tsx
@@ -7,9 +7,11 @@ import { useSearchList } from "@/hooks/useSearchList";
 import { Accommodation } from "./AccommodationGridView.types";
 import { printCategory } from "@/utils/printCategory";
 import { Spinner } from "@chakra-ui/react";
+import { useNavigateToResultPage } from "@/hooks/useNavigateToResultPage";
 
 export const AccommodationGridView = () => {
-  const [activeTab, setActiveTab] = useState('펜션'); 
+  const { navigateToResultPage } = useNavigateToResultPage();
+  const [activeTab, setActiveTab] = useState('pension'); 
   
   const handleTabClick = (tab: string) => {
     startTransition(() => { 
@@ -18,7 +20,7 @@ export const AccommodationGridView = () => {
   };
 
   const { data, error } = useSearchList(
-    null,
+    '제주', 
     null,
     null,
     null,
@@ -54,15 +56,15 @@ export const AccommodationGridView = () => {
       <styled.CategoryTapWrapper>
         <styled.CategoryTapContainer>
           <styled.CategoryTap>
-            <styled.CategoryTapItem onClick={() => handleTabClick('펜션')}>
-              <styled.TabItem $isActive={activeTab === '펜션'} onClick={() => handleTabClick('펜션')}>
-                {activeTab === '펜션' && <styled.ActivedBar />}
+            <styled.CategoryTapItem onClick={() => handleTabClick('pension')}>
+              <styled.TabItem $isActive={activeTab === 'pension'} onClick={() => handleTabClick('pension')}>
+                {activeTab === 'pension' && <styled.ActivedBar />}
                 펜션
               </styled.TabItem>
             </styled.CategoryTapItem>
-            <styled.CategoryTapItem onClick={() => handleTabClick('호텔')}>
-              <styled.TabItem $isActive={activeTab === '호텔'}>
-                {activeTab === '호텔' && <styled.ActivedBar />}
+            <styled.CategoryTapItem onClick={() => handleTabClick('hotel')}>
+              <styled.TabItem $isActive={activeTab === 'hotel'}>
+                {activeTab === 'hotel' && <styled.ActivedBar />}
                 호텔
               </styled.TabItem>
             </styled.CategoryTapItem>
@@ -83,7 +85,7 @@ export const AccommodationGridView = () => {
       </styled.GridWrapper>
       <styled.MoreButtonWrapper>
         <a>
-          <styled.MoreButton>
+          <styled.MoreButton onClick={() => navigateToResultPage(activeTab, 'jeju')}>
             <styled.MoreButtonTxt>모두 보기</styled.MoreButtonTxt>
             <ArrowForwardIcon />
           </styled.MoreButton>

--- a/src/components/Main/AccommodationGridView/AccommodationGridView.tsx
+++ b/src/components/Main/AccommodationGridView/AccommodationGridView.tsx
@@ -76,6 +76,7 @@ export const AccommodationGridView = () => {
         {data?.accommodations?.map((accommodation: Accommodation, index: number) => (
           <AccommodationGridItem
             key={index}
+            id={accommodation.id}
             imageUrl={accommodation.thumbnail}
             summary={`${accommodation.region} | ${printCategory(accommodation.type)}`}
             name={accommodation.name}

--- a/src/components/Main/AccommodationGridView/AccommodationGridView.types.ts
+++ b/src/components/Main/AccommodationGridView/AccommodationGridView.types.ts
@@ -1,4 +1,5 @@
 export interface GridItemProps {
+  id: number;
   imageUrl: string;
   summary: string;
   name: string;

--- a/src/components/Main/AccommodationSingleView/AccommodationSingleView.styles.ts
+++ b/src/components/Main/AccommodationSingleView/AccommodationSingleView.styles.ts
@@ -33,6 +33,10 @@ export const MoreButtonWrapper = styled.div`
   bottom: 0px;
   right: 24px;
   margin-bottom: 18px;
+
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 export const MoreButtonTxt = styled.div`

--- a/src/components/Main/AccommodationSingleView/AccommodationSingleView.tsx
+++ b/src/components/Main/AccommodationSingleView/AccommodationSingleView.tsx
@@ -6,8 +6,10 @@ import { useSearchList } from "@/hooks/useSearchList";
 import { Spinner } from "@chakra-ui/react";
 import { Accommodation } from "../AccommodationGridView/AccommodationGridView.types";
 import { printCategory } from "@/utils/printCategory";
+import { useNavigateToResultPage } from "@/hooks/useNavigateToResultPage";
 
 export const AccommodationSingleView = () => {
+  const { navigateToResultPage } = useNavigateToResultPage();
   const [currentSlide, setCurrentSlide] = useState<number>(0);
 
   const settings = {
@@ -72,11 +74,9 @@ export const AccommodationSingleView = () => {
             <styled.Title>호캉스</styled.Title>
             <styled.Description>지친 이번주, 호캉스는 어떠세요?</styled.Description>
           </styled.MainViewTitle>
-          <styled.MoreButtonWrapper>
-            <a href="/searchResult">
-              <styled.MoreButtonTxt>모두 보기</styled.MoreButtonTxt>
-              <ArrowForwardIcon color={"#666666"}/>
-            </a>
+          <styled.MoreButtonWrapper onClick={() => navigateToResultPage('hotel', '')}>
+            <styled.MoreButtonTxt>모두 보기</styled.MoreButtonTxt>
+            <ArrowForwardIcon color={"#666666"}/>
           </styled.MoreButtonWrapper>
         </styled.MainViewTitleWrapper>
         <styled.SwiperContainer>

--- a/src/components/Main/AccommodationSingleView/AccommodationSingleView.tsx
+++ b/src/components/Main/AccommodationSingleView/AccommodationSingleView.tsx
@@ -7,9 +7,11 @@ import { Spinner } from "@chakra-ui/react";
 import { Accommodation } from "../AccommodationGridView/AccommodationGridView.types";
 import { printCategory } from "@/utils/printCategory";
 import { useNavigateToResultPage } from "@/hooks/useNavigateToResultPage";
+import { useNavigateToDetailPage } from "@/hooks/useNavigateToDetailPage";
 
 export const AccommodationSingleView = () => {
   const { navigateToResultPage } = useNavigateToResultPage();
+  const { navigateToDetailPage } = useNavigateToDetailPage();
   const [currentSlide, setCurrentSlide] = useState<number>(0);
 
   const settings = {
@@ -82,7 +84,7 @@ export const AccommodationSingleView = () => {
         <styled.SwiperContainer>
           <styled.StyledSlider {...settings}>
             {data?.accommodations?.map((item: Accommodation, index: number) => (
-              <styled.SwiperItem key={index}>
+              <styled.SwiperItem key={index} onClick={() => navigateToDetailPage(item.id)}>
                 <img src={item.thumbnail} alt={`Slide ${index + 1}`} />
               </styled.SwiperItem>
             ))}

--- a/src/components/Main/MainCategoryMenu/MainCategoryMenuItem.tsx
+++ b/src/components/Main/MainCategoryMenu/MainCategoryMenuItem.tsx
@@ -14,7 +14,7 @@ export const MainCategoryMenuItem: React.FC<MainCategoryMenuItemProps> = ({
 
   return (
     <styled.CategoryMenuItem
-      onClick={() => navigateToResultPage(category)}
+      onClick={() => navigateToResultPage(category, '')}
     >
       <styled.MenuIcon>
         {React.cloneElement(icon, { size, color: iconColor })}

--- a/src/hooks/useNavigateToDetailPage.ts
+++ b/src/hooks/useNavigateToDetailPage.ts
@@ -1,0 +1,19 @@
+import { useNavigate } from "react-router-dom";
+import { getToday, getTomorrow } from "@/utils/getTodayTomorrow";
+import { convertDateFormat4 } from "@/utils/convertDateFormat4";
+
+export const useNavigateToDetailPage = () => {
+  const navigate = useNavigate();
+
+  // defualt date
+  const today = convertDateFormat4(getToday());
+  const tomorrow = convertDateFormat4(getTomorrow());
+
+  const navigateToDetailPage = (id: number) => {
+    navigate(`/products?id=${id}&startDate=${today}&endDate=${tomorrow}`);
+  };
+
+  return {
+    navigateToDetailPage
+  };
+};

--- a/src/hooks/useNavigateToResultPage.ts
+++ b/src/hooks/useNavigateToResultPage.ts
@@ -3,8 +3,15 @@ import { useNavigate } from "react-router-dom";
 export const useNavigateToResultPage = () => {
   const navigate = useNavigate();
 
-  const navigateToResultPage = (category: string) => {
-    navigate(`/searchResult?category=${category}`);
+  const navigateToResultPage = (category: string, region: string) => {
+    let url = '/searchResult?'
+
+    if (category)
+      url += `category=${category}`;
+    if (region)
+      url += `&region=${region}`;
+
+    navigate(url);
   };
 
   return {

--- a/src/utils/getTodayTomorrow.ts
+++ b/src/utils/getTodayTomorrow.ts
@@ -1,0 +1,20 @@
+export const formatDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+export const getToday = (): string => {
+  const today = new Date();
+
+  return formatDate(today);
+}
+
+export const getTomorrow = (): string => {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  return formatDate(tomorrow);
+}


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #59 

## 작업 내용 (변경 사항)
- 모두 보기 버튼 눌렀을 때 검색 결과 페이지로 navigate
  - 기존 category 쿼리는 동일하고, 새로 추가된 `region` 쿼리 부분 추가 부탁 드립니다! 
  - **그리드 뷰**에서 넘어갈 때만 `category`, `region` 두 개 보내드리고, 나머지는 `category`만 보내드립니다.
  - `searchParam` 사용하셔서 지역 select **제주도**로 설정되면 됩니다 🙏🍊 @seungsimdang  
  - (메인 페이지에서 다른 지역 값 보낼 일은 없습니다)
- 숙소 이미지 눌렀을 때 해당 상세 페이지로 navigate
  - 검색 페이지에서 넘어갈 때와 동일하게`숙소 id`, `체크인 날짜`, `체크아웃 날짜` 보내드립니다!
  -  `searchParam` 사용하셔서 설정해주시면 됩니다 🙏🛌 @lilviolie 

## 스크린샷
### 검색 결과 페이지 url
<img width="414" alt="image" src="https://github.com/YBEMiniProjectTeam/MINI-Front/assets/63582234/28af9b88-ae89-4851-bb32-3bf477764b8b">

### 숙소 상세 페이지 url
<img width="513" alt="image" src="https://github.com/YBEMiniProjectTeam/MINI-Front/assets/63582234/31fffbf7-e918-4d6a-b0bc-5d66896f1d34">

## 리뷰 요청 사항
hooks/ `useNavigateToResultPage`, `useNavigateToDetailPage` 확인해주시면 좋을 것 같습니다.
부탁드린 추가 사항 확인하시고 궁금하신 점 코멘트 남겨주세요!!🙇🏻‍♀️