### PR TITLE
Fix: 카테고리 메뉴 navigate 시 한글로 수정

### DIFF
--- a/src/components/Main/MainCategoryMenu/MainCategoryMenu.tsx
+++ b/src/components/Main/MainCategoryMenu/MainCategoryMenu.tsx
@@ -14,31 +14,31 @@ export const MainCategoryMenu = () => {
           icon={<AllIcon />} 
           size="2.3rem" 
           title="모든 숙소" 
-          category="all"
+          category=""
         />
         <MainCategoryMenuItem 
           icon={<HotelIcon />} 
           size="1.9rem" 
           title="호텔"
-          category="hotel"
+          category="호텔"
         />
         <MainCategoryMenuItem 
           icon={<ResortIcon />} 
           size="1.9rem" 
           title="리조트"
-          category="resort"
+          category="리조트"
         />
         <MainCategoryMenuItem 
           icon={<MotelIcon />} 
           size="2.4rem" 
           title="모텔" 
-          category="motel"
+          category="모텔"
         />
         <MainCategoryMenuItem 
           icon={<PensionIcon />} 
           size="2.2rem" 
           title="펜션" 
-          category="pension"
+          category="펜션"
         />
       </styled.CategoryMenuWrapper>
     </styled.CategoryWrapper>


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #103 

## 작업 내용 (변경 사항)
카테고리 메뉴 navigate 시 영어 -> 한글로 수정 (API 로직 수정에 맞춰 변경)

## 스크린샷
<img width="338" alt="image" src="https://github.com/YBEMiniProjectTeam/MINI-Front/assets/63582234/91723671-4832-4271-8d73-a5b090c944bb">