### PR TITLE
Fix: 헤더 검색창 가운데 정렬

### DIFF
--- a/src/components/Layout/Header/Header.styles.ts
+++ b/src/components/Layout/Header/Header.styles.ts
@@ -15,7 +15,7 @@ export const HeaderContainer = styled.div`
   padding: 0px 24px;
 
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
   align-items: center;
 
   z-index: 10;
@@ -82,7 +82,9 @@ export const HeaderContainer = styled.div`
     }
   }
 `;
-export const InputContainer = styled.form`
+export const InputContainer = styled.form<{ $isLogin: boolean }>`
+  transform: ${({$isLogin }) => ($isLogin ? "translate(50%, 0) translateX(-241px)" : "")};
+
   .input-container {
     position: relative;
     margin: 0px 32px;

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -79,7 +79,7 @@ export const Header = () => {
         <Link to="/">
           <div className="header-title">NINE STAY</div>
         </Link>
-        {isShowInput ? <HeaderInput /> : null}
+        {isShowInput ? <HeaderInput accessToken={accessToken!}/> : null}
 
         <div className="menu-container">
           {accessToken ? null : (

--- a/src/components/Layout/Header/HeaderInput.tsx
+++ b/src/components/Layout/Header/HeaderInput.tsx
@@ -3,9 +3,14 @@ import { BsSearch, BsFillXCircleFill } from "react-icons/bs";
 import { useNavigate } from "react-router-dom";
 import * as styles from "./Header.styles";
 
-export const HeaderInput = () => {
+export interface HeaderProps {
+  accessToken: string;
+}
+
+export const HeaderInput = ({ accessToken }: HeaderProps) => {
   const navigate = useNavigate();
   const [inputValue, setInputValue] = useState("");
+  const isLogin = accessToken ? true : false;
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.currentTarget.value);
@@ -21,7 +26,7 @@ export const HeaderInput = () => {
     navigate(`/searchResult?keyword=${inputValue}`);
   };
   return (
-    <styles.InputContainer onSubmit={handleSubmit}>
+    <styles.InputContainer $isLogin={isLogin} onSubmit={handleSubmit}>
       <div className="input-container">
         <input
           type="text"


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #203 

## 작업 내용 (변경 사항)
헤더 검색창 가운데 정렬되도록 수정했습니다.
- 로그인 시 타이틀 로고 위치도 움직여서 `space-around` -> `space-between`으로 수정했습니다.
- 헤더 -> 검색창 props로 access token이 존재하는지 검사한 후 로그인 했다면 검색창 크기/2만큼 translateX 적용하여 가운데 정렬해주었습니다.
```
transform: ${({$isLogin }) => ($isLogin ? "translate(50%, 0) translateX(-241px)" : "")};
```

## 스크린샷
<img width="1461" alt="스크린샷 2023-12-15 오전 3 05 13" src="https://github.com/YBEMiniProjectTeam/MINI-Front/assets/63582234/59f58180-b86a-4dc6-b826-55d886a23930">
<img width="1461" alt="image" src="https://github.com/YBEMiniProjectTeam/MINI-Front/assets/63582234/0dd48fb1-47d4-4624-aa47-cb521e325958">


## 리뷰 요청 사항
제가 테스트 했을 때는 잘 적용됐는데, 머지된 후에 다른 분들도 가운데 정렬 잘 되는지 확인 부탁드립니다!