### PR TITLE
Feat: 결제 시 재고없을 경우 에러 핸들링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist-ssr
 *.sw?
 
 .env.local
+.env
 /test-results/
 /playwright-report/
 /blob-report/

--- a/src/hooks/useSendPaymentMutation.ts
+++ b/src/hooks/useSendPaymentMutation.ts
@@ -1,19 +1,39 @@
+import axios from "axios";
 import { useMutation } from "@tanstack/react-query";
 import type { ResponseType } from "@api/ApiResponse.types";
 import { postPayment, PaymentInfoProps } from "@api/postPayment";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-hot-toast";
 
 export const useSendPaymentMutation = () => {
   const navigate = useNavigate();
+
+  const handleUnexpectedStatusCode = (statusCode: number) => {
+    if (statusCode === 400) {
+      toast.error("재고가 부족합니다. 결제 요청이 실패했습니다.");
+    }
+    navigate(-1);
+  };
 
   return useMutation<ResponseType, Error, PaymentInfoProps>({
     mutationFn: ({ cart_ids, guest_name, guest_email }: PaymentInfoProps) =>
       postPayment({ cart_ids, guest_name, guest_email }),
 
     onSuccess: (res, variables) => {
-      console.log(res);
+      if (res.statusCode && res.statusCode !== 200) {
+        handleUnexpectedStatusCode(res.statusCode);
+        return;
+      }
       const orderId = `orderId=${variables.cart_ids.length}`;
       navigate(`/reservationComplete?${orderId}`);
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) {
+        const statusCode = err.response?.status;
+        handleUnexpectedStatusCode(statusCode!);
+      } else {
+        throw err;
+      }
     }
   });
 };


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #207 

## 작업 내용 (변경 사항)
- 결제 시 재고없는 경우 "재고가 부족합니다. 결제 요청이 실패했습니다." 토스트 메시지 띄어주고 이전 화면으로 이동시키는 로직 추가


## 스크린샷
https://github.com/YBEMiniProjectTeam/MINI-Front/assets/139189221/39b2adc4-cb42-4474-a77e-07390311410f


## 테스트 결과


## 리뷰 요청 사항
