### PR TITLE
Fix: 에러바운더리 초기화 안되는 이슈

### DIFF
--- a/src/components/AsyncWrapper/AsyncWrapper.types.ts
+++ b/src/components/AsyncWrapper/AsyncWrapper.types.ts
@@ -20,6 +20,7 @@ export type ErrorBoundaryProps = {
   fallback: ComponentType<FallbackProps>;
   onReset: () => void;
   children: ReactNode;
+  resetKey: string;
 };
 
 export interface DeferredComponentProps {

--- a/src/components/AsyncWrapper/ErrorBoundary.tsx
+++ b/src/components/AsyncWrapper/ErrorBoundary.tsx
@@ -45,6 +45,14 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     console.log({ error, errorInfo });
   }
 
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    if (this.props.resetKey !== prevProps.resetKey) {
+      if (this.state.hasError) {
+        this.resetErrorBoundary();
+      }
+    }
+  }
+
   render() {
     const { state, props, resetErrorBoundary } = this;
 

--- a/src/components/AsyncWrapper/index.tsx
+++ b/src/components/AsyncWrapper/index.tsx
@@ -6,8 +6,13 @@ import type { AsyncWrapperProps } from "./AsyncWrapper.types";
 
 const AsyncWrapper = ({ children, fallback }: AsyncWrapperProps) => {
   const { reset } = useQueryErrorResetBoundary();
+  console.log(location.pathname);
   return (
-    <ErrorBoundary fallback={ErrorFallback} onReset={reset}>
+    <ErrorBoundary
+      fallback={ErrorFallback}
+      onReset={reset}
+      resetKey={location.pathname}
+    >
       <Suspense fallback={fallback}>{children}</Suspense>
     </ErrorBoundary>
   );

--- a/src/hooks/login/useLoginMutation.ts
+++ b/src/hooks/login/useLoginMutation.ts
@@ -31,7 +31,8 @@ export const useLoginMutation = () => {
         window.localStorage.setItem("access-token", res.data.accessToken);
         console.log(res.data.accessToken);
 
-        navigate(loginUrl + loginUrlSearch);
+        navigate(loginUrl + loginUrlSearch, { replace: true });
+        window.location.reload();
       } else if (res.statusCode === 400) {
         toast.error("아이디 혹은 비밀번호가 잘못되었습니다.");
       }


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #208

## 작업 내용 (변경 사항)
- 상황: 인증이 필요한 페이지 접속 -> 에러바운더리에서 fallback 보여줌 -> 로그인 후 재접속 -> 여전히 에러 fallback 보임
- 에러바운더리 초기화 안되는 이슈가 있었는데, 일단 현재 주소가 바뀔 때마다 에러를 리셋하는 로직은 추가해뒀습니다.
- 근데 api 요청 갈 때부터 401 에러를 뱉어서 에러바운더리 쪽 보다는, 로그인 후에 이전 페이지로 navigate 할 때 계속 토큰이 안담긴 채로 요청을 보내는게 아닌가 싶습니다.. 🥲
- 해결: 로그인 후에 리로드 시키는 로직을 추가했습니다. 그래서 기존에 로그인 요청 보낼 때 payload가 네트워크 기록에 남아있던 문제도 해결되긴 햇습니당... 이게 정공법은 아닌 것 같은데 어렵네요 🥲

## 스크린샷


## 테스트 결과


## 리뷰 요청 사항
혹시 시간되시면 이 문제 배포페이지나 로컬에서 확인해주실 수 있을까요?
로그인 후에도 왜 401이 에러가 날까요 🤔..
